### PR TITLE
Splits MeetupServer into its own module

### DIFF
--- a/meetup/Cargo.toml
+++ b/meetup/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 publish = false
 edition = "2018"
 
+[lib]
+name = "meetup_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "meetup"
+path = "src/main.rs"
+
 [dependencies]
 bytes = "0.5"
 post = { version = "0.1.0", path = "../lib" }

--- a/meetup/Cargo.toml
+++ b/meetup/Cargo.toml
@@ -9,7 +9,7 @@ name = "meetup_server"
 path = "src/lib.rs"
 
 [[bin]]
-name = "meetup"
+name = "post-meetup"
 path = "src/main.rs"
 
 [dependencies]

--- a/meetup/src/lib.rs
+++ b/meetup/src/lib.rs
@@ -1,0 +1,140 @@
+extern crate tokio;
+use futures::{future, stream::StreamExt};
+use log::*;
+use post::{
+    find_service,
+    find_service::{proto, proto::find_me_server::FindMe},
+};
+use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
+use std::io;
+use std::result::Result;
+use std::sync::{Arc, RwLock};
+use std::time;
+use time::SystemTime;
+use tonic::{Request, Response, Status};
+
+fn convert_system_time_error(time_error: time::SystemTimeError) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, time_error)
+}
+
+type PublisherStore = Arc<RwLock<HashMap<String, proto::Registration>>>;
+
+#[derive(Default, Clone)]
+pub struct MeetupServer {
+    publisher_store: PublisherStore,
+    publisher_timeout: time::Duration,
+}
+
+impl MeetupServer {
+    pub fn new(timeout: time::Duration) -> MeetupServer {
+        MeetupServer {
+            publisher_store: Arc::new(RwLock::new(HashMap::new())),
+            publisher_timeout: timeout,
+        }
+    }
+
+    pub fn start_remove_process(&self) {
+        self.remove_expired_publishers();
+    }
+
+    fn remove_expired_publishers(&self) {
+        let pub_store = self.publisher_store.clone();
+        let pub_timeout = self.publisher_timeout;
+
+        let _tokio_task = tokio::spawn(tokio::time::interval(pub_timeout).for_each(move |_| {
+            let now = time::SystemTime::now();
+            pub_store.write().unwrap().retain(|_k, v| {
+                if let Some(info) = &v.info {
+                    if let Some(expiration) = &info.expiration {
+                        match expiration.try_into() {
+                            Result::<time::SystemTime, _>::Ok(proto_time) => proto_time > now,
+                            Err(error) => {
+                                error!("Removing descriptor, Invalid time: {}", error);
+                                false
+                            }
+                        }
+                    } else {
+                        error!("Removing descriptor, No Expiration");
+                        false
+                    }
+                } else {
+                    error!("Removing descriptor, No ConnectionInfo");
+                    false
+                }
+            });
+            future::ready(())
+        }));
+    }
+}
+
+#[tonic::async_trait]
+impl FindMe for MeetupServer {
+    async fn server_status(
+        &self,
+        _tonic_request: Request<proto::StatusRequest>,
+    ) -> Result<Response<proto::StatusResponse>, Status> {
+        let locked = self.publisher_store.write().unwrap();
+
+        let reply = proto::StatusResponse {
+            count: locked.len() as u64,
+        };
+        Ok(Response::new(reply))
+    }
+    async fn publisher_register(
+        &self,
+        tonic_request: Request<proto::RegistrationRequest>,
+    ) -> Result<Response<proto::RegistrationResponse>, Status> {
+        let request = tonic_request.into_inner();
+        let last_report =
+            Some(proto::Time::try_from(SystemTime::now()).map_err(convert_system_time_error)?);
+        let expiration = Some(
+            proto::Time::try_from(SystemTime::now() + self.publisher_timeout)
+                .map_err(convert_system_time_error)?,
+        );
+        let name;
+        let registration = proto::Registration {
+            publisher: match request.desc {
+                Some(desc) => {
+                    name = desc.name.clone();
+                    Some(desc)
+                }
+                None => {
+                    return Err(find_service::MissingFieldError::new("Registration", "desc")
+                        .try_into()
+                        .unwrap())
+                }
+            },
+            info: Some(proto::ConnectionInfo {
+                last_report,
+                expiration,
+            }),
+        };
+        {
+            let mut locked = self.publisher_store.write().unwrap();
+            locked.insert(name, registration);
+        }
+
+        let reply = proto::RegistrationResponse {
+            expiration_interval: Some(self.publisher_timeout.into()),
+        };
+        Ok(Response::new(reply))
+    }
+
+    async fn get_publishers(
+        &self,
+        tonic_request: Request<proto::SearchRequest>,
+    ) -> Result<Response<proto::SearchResponse>, Status> {
+        let request = tonic_request.into_inner();
+        let locked = self.publisher_store.read().unwrap();
+
+        let list = if let Some(val) = locked.get(&request.name_regex) {
+            vec![val.clone()]
+        } else {
+            vec![]
+        };
+
+        let reply = proto::SearchResponse { list };
+        Ok(Response::new(reply))
+    }
+}

--- a/meetup/src/lib.rs
+++ b/meetup/src/lib.rs
@@ -11,9 +11,9 @@ use std::io;
 use std::result::Result;
 use std::sync::{Arc, RwLock};
 use std::time;
+use time::Duration;
 use time::SystemTime;
 use tonic::{Request, Response, Status};
-use time::Duration;
 
 fn convert_system_time_error(time_error: time::SystemTimeError) -> io::Error {
     io::Error::new(io::ErrorKind::Other, time_error)
@@ -38,7 +38,7 @@ impl MeetupServer {
         MeetupServer {
             publisher_store: Arc::new(RwLock::new(HashMap::new())),
             publisher_timeout: options.publisher_timeout,
-            publisher_scan_interval: options.publisher_scan_interval
+            publisher_scan_interval: options.publisher_scan_interval,
         }
     }
 

--- a/meetup/src/main.rs
+++ b/meetup/src/main.rs
@@ -43,7 +43,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .get_matches();
 
-    matches.value_of("publisher-scan-interval").unwrap();
     let publisher_timeout = Duration::from_secs(
         matches
             .value_of("publisher-timeout")

--- a/meetup/src/main.rs
+++ b/meetup/src/main.rs
@@ -8,8 +8,8 @@ use time::Duration;
 
 use post::find_service::proto::find_me_server::FindMeServer;
 
+use meetup_server::{MeetupServer, MeetupServerOptions};
 use tonic::transport::Server;
-use meetup_server::MeetupServer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -51,9 +51,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .parse()
             .unwrap(),
     );
+
+    let scan_interval = Duration::from_secs(
+        matches
+            .value_of("publisher-scan-interval")
+            .unwrap()
+            .parse()
+            .unwrap(),
+    );
     let bind_info = matches.value_of("bind").unwrap().parse().unwrap();
 
-    let meetup_server = MeetupServer::new(publisher_timeout);
+    let meetup_server_options = MeetupServerOptions {
+        publisher_timeout: publisher_timeout,
+        publisher_scan_interval: scan_interval,
+    };
+    let meetup_server = MeetupServer::new(meetup_server_options);
     meetup_server.start_remove_process();
 
     let server = Server::builder()

--- a/meetup/src/main.rs
+++ b/meetup/src/main.rs
@@ -1,153 +1,15 @@
 extern crate tokio;
 use clap::{crate_authors, App as ClApp, Arg};
-use futures::{future, stream::StreamExt};
 use log::*;
-use post::{
-    find_service,
-    find_service::{
-        proto,
-        proto::find_me_server::{FindMe, FindMeServer},
-    },
-};
-use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
-use std::io;
 use std::net::ToSocketAddrs;
 use std::result::Result;
-use std::sync::{Arc, RwLock};
 use std::time;
-use time::{Duration, SystemTime};
-use tonic::{transport::Server, Request, Response, Status};
+use time::Duration;
 
-fn convert_system_time_error(time_error: time::SystemTimeError) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, time_error)
-}
+use post::find_service::proto::find_me_server::FindMeServer;
 
-#[derive(Default)]
-struct ServerState {
-    publishers: HashMap<String, proto::Registration>,
-}
-
-impl ServerState {
-    pub fn new() -> ServerState {
-        ServerState {
-            publishers: HashMap::new(),
-        }
-    }
-}
-
-type Inner = Arc<RwLock<ServerState>>;
-
-#[derive(Default, Clone)]
-struct ProtectedState {
-    inner: Inner,
-    publisher_timeout: time::Duration,
-}
-
-#[tonic::async_trait]
-impl FindMe for ProtectedState {
-    async fn server_status(
-        &self,
-        _tonic_request: Request<proto::StatusRequest>,
-    ) -> Result<Response<proto::StatusResponse>, Status> {
-        let locked = self.inner.write().unwrap();
-
-        let reply = proto::StatusResponse {
-            count: locked.publishers.len() as u64,
-        };
-        Ok(Response::new(reply))
-    }
-    async fn publisher_register(
-        &self,
-        tonic_request: Request<proto::RegistrationRequest>,
-    ) -> Result<Response<proto::RegistrationResponse>, Status> {
-        let request = tonic_request.into_inner();
-        let last_report =
-            Some(proto::Time::try_from(SystemTime::now()).map_err(convert_system_time_error)?);
-        let expiration = Some(
-            proto::Time::try_from(SystemTime::now() + self.publisher_timeout)
-                .map_err(convert_system_time_error)?,
-        );
-        let name;
-        let registration = proto::Registration {
-            publisher: match request.desc {
-                Some(desc) => {
-                    name = desc.name.clone();
-                    Some(desc)
-                }
-                None => {
-                    return Err(find_service::MissingFieldError::new("Registration", "desc")
-                        .try_into()
-                        .unwrap())
-                }
-            },
-            info: Some(proto::ConnectionInfo {
-                last_report,
-                expiration,
-            }),
-        };
-        {
-            let mut locked = self.inner.write().unwrap();
-            locked.publishers.insert(name, registration);
-        }
-
-        let reply = proto::RegistrationResponse {
-            expiration_interval: Some(self.publisher_timeout.into()),
-        };
-        Ok(Response::new(reply))
-    }
-    async fn get_publishers(
-        &self,
-        tonic_request: Request<proto::SearchRequest>,
-    ) -> Result<Response<proto::SearchResponse>, Status> {
-        let request = tonic_request.into_inner();
-        let locked = self.inner.read().unwrap();
-
-        let list = if let Some(val) = locked.publishers.get(&request.name_regex) {
-            vec![val.clone()]
-        } else {
-            vec![]
-        };
-
-        let reply = proto::SearchResponse { list };
-        Ok(Response::new(reply))
-    }
-}
-
-fn remove_expired_publishers(s: Inner, i: time::Duration) {
-    tokio::spawn(tokio::time::interval(i).for_each(move |_| {
-        let now = time::SystemTime::now();
-        s.write().unwrap().publishers.retain(|_k, v| {
-            if let Some(info) = &v.info {
-                if let Some(expiration) = &info.expiration {
-                    match expiration.try_into() {
-                        Result::<time::SystemTime, _>::Ok(proto_time) => proto_time > now,
-                        Err(error) => {
-                            error!("Removing descriptor, Invalid time: {}", error);
-                            false
-                        }
-                    }
-                } else {
-                    error!("Removing descriptor, No Expiration");
-                    false
-                }
-            } else {
-                error!("Removing descriptor, No ConnectionInfo");
-                false
-            }
-        });
-        future::ready(())
-    }));
-}
-
-fn socket_validator(v: String) -> Result<(), String> {
-    match v.to_socket_addrs() {
-        Ok(_) => Ok(()),
-        Err(_) => Err(String::from(
-            "Value does not specify a hostname:port value to bind to",
-        )),
-    }
-}
+use tonic::transport::Server;
+use meetup_server::MeetupServer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -181,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .get_matches();
 
-    let scan_interval = matches.value_of("publisher-scan-interval").unwrap();
+    matches.value_of("publisher-scan-interval").unwrap();
     let publisher_timeout = Duration::from_secs(
         matches
             .value_of("publisher-timeout")
@@ -190,22 +52,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap(),
     );
     let bind_info = matches.value_of("bind").unwrap().parse().unwrap();
-    let state = ProtectedState {
-        inner: Arc::new(RwLock::new(ServerState::new())),
-        publisher_timeout,
-    };
-    let state_for_cleaner = state.inner.clone();
 
-    remove_expired_publishers(
-        state_for_cleaner,
-        Duration::from_secs(scan_interval.parse().unwrap()),
-    );
+    let meetup_server = MeetupServer::new(publisher_timeout);
+    meetup_server.start_remove_process();
 
     let server = Server::builder()
-        .add_service(FindMeServer::new(state))
+        .add_service(FindMeServer::new(meetup_server))
         .serve(bind_info);
+
     info!("Started server {}", bind_info);
     server.await?;
 
     Ok(())
+}
+
+pub fn socket_validator(v: String) -> Result<(), String> {
+    match v.to_socket_addrs() {
+        Ok(_) => Ok(()),
+        Err(_) => Err(String::from(
+            "Value does not specify a hostname:port value to bind to",
+        )),
+    }
 }


### PR DESCRIPTION
Addresses issue #26 

Also flattens the server's internal state into a single struct, in
preparation for a public trait for publisher data stores.