### PR TITLE
Publisher: included more meetup in tests and fallout from that

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,3 +28,5 @@ jobs:
       #run: cargo clippy
     - name: Run tests
       run: cargo test --verbose
+    - name: Rust Format
+      run: cargo fmt -- --check

--- a/examples/stdin_publisher.rs
+++ b/examples/stdin_publisher.rs
@@ -5,7 +5,7 @@ use futures::{
     sink::SinkExt,
     stream::{StreamExt, TryStreamExt},
 };
-use post::{PublisherDesc, publisher::Publisher};
+use post::{publisher::Publisher, PublisherDesc};
 use std::error::Error as StdError;
 use std::time::Duration;
 use tokio_util::codec;
@@ -49,9 +49,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
         .get_matches();
 
     let url = String::from(matches.value_of("url").unwrap());
-    let client = post::find_service::Client::from_url(url)?
-        .connect()
-        .await?;
+    let client = post::find_service::Client::from_url(url)?.connect().await?;
     let name = "stdin".to_string();
     let host_name = matches.value_of("host").unwrap().to_string();
     let port = matches
@@ -69,7 +67,8 @@ async fn main() -> Result<(), Box<dyn StdError>> {
             name,
             host_name,
             port,
-            subscriber_expiration_interval: Duration::new(subscriber_timeout, 0),},
+            subscriber_expiration_interval: Duration::new(subscriber_timeout, 0),
+        },
         client,
     )
     .await?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time;
-use tokio::{net::UdpSocket, time as timer};
+use tokio::{net::UdpSocket, time as timer, sync::oneshot::error::RecvError as OneshotRecvError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -23,6 +23,7 @@ pub enum Error {
     IoError(io::Error),
     FramingError(framing::Error),
     TimerError(timer::Error),
+    OneshotError(OneshotRecvError),
 }
 
 type DataGram = (framing::Message, SocketAddr);
@@ -37,6 +38,7 @@ impl std::fmt::Display for Error {
             Error::FramingError(e) => write!(f, "Framing Error: {}", e),
             Error::AddrParseError => write!(f, "Error Parsing Address"),
             Error::TimerError(e) => write!(f, "Error in tokio timer: {}", e),
+            Error::OneshotError(e) => write!(f, "Error in internal messaging:{}", e),
         }
     }
 }
@@ -64,6 +66,12 @@ impl From<framing::Error> for Error {
 impl From<timer::Error> for Error {
     fn from(err: timer::Error) -> Error {
         Error::TimerError(err)
+    }
+}
+
+impl From<OneshotRecvError> for Error {
+    fn from(err: OneshotRecvError) -> Error {
+        Error::OneshotError(err)
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time;
-use tokio::{net::UdpSocket, time as timer, sync::oneshot::error::RecvError as OneshotRecvError};
+use tokio::{net::UdpSocket, sync::oneshot::error::RecvError as OneshotRecvError, time as timer};
 
 #[derive(Debug)]
 pub enum Error {

--- a/lib/src/publisher.rs
+++ b/lib/src/publisher.rs
@@ -143,7 +143,7 @@ async fn publisher_registration(
     desc: PublisherDesc,
     client: find_service::Client,
     shared: Arc<Mutex<PublisherShared>>,
-) ->Result<()> {
+) -> Result<()> {
     let (reg_sender, reg_listener) = tokio::sync::oneshot::channel::<bool>();
     let reg_info = Arc::new((client, desc));
     tokio::spawn(async move {
@@ -164,7 +164,8 @@ async fn publisher_registration(
                         //if the other side is not listening, we don't care
                         let _ = sender.send(true);
                     }
-                    ((), resp.expiration_interval / 2)},
+                    ((), resp.expiration_interval / 2)
+                }
                 Err(_) => ((), interval),
             })
         } else {

--- a/meetup/src/main.rs
+++ b/meetup/src/main.rs
@@ -106,7 +106,7 @@ impl FindMe for ProtectedState {
         let list = if let Some(val) = locked.publishers.get(&request.name_regex) {
             vec![val.clone()]
         } else {
-            unimplemented!()
+            vec![]
         };
 
         let reply = proto::SearchResponse { list };

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate log;
 
+mod common;
 mod publisher_subscriber;
 mod verify;
-mod common;

--- a/tests/src/publisher_subscriber.rs
+++ b/tests/src/publisher_subscriber.rs
@@ -3,7 +3,7 @@ extern crate log;
 #[macro_use]
 use crate::verify::{self, VerificationStatus, Verifier};
 use futures::{sink::SinkExt, stream::StreamExt, TryFutureExt};
-use std::{sync::Arc, convert::TryFrom};
+use std::{convert::TryFrom, sync::Arc};
 
 use crate::common;
 
@@ -49,16 +49,31 @@ async fn publisher_subscriber_basics() {
         .await
         .expect("Unable to create Publisher");
 
-    assert_ne!(client.server_status().await.expect("Unable to retreive status").count, 0);
+    assert_ne!(
+        client
+            .server_status()
+            .await
+            .expect("Unable to retreive status")
+            .count,
+        0
+    );
 
     debug!("Searching for publisher");
-    let found_publisher = client.get_descriptors_for_name(publisher_name).await
+    let found_publisher = client
+        .get_descriptors_for_name(publisher_name)
+        .await
         .expect("Error finding publisher")
-        .list.pop().expect("No publisher found");
+        .list
+        .pop()
+        .expect("No publisher found");
 
-    assert_eq!(found_publisher.info.is_some(),true);
+    assert_eq!(found_publisher.info.is_some(), true);
 
-    let found_publisher_desc = post::PublisherDesc::try_from(found_publisher.publisher.expect("Publisher did not contain a description"))
+    let found_publisher_desc = post::PublisherDesc::try_from(
+        found_publisher
+            .publisher
+            .expect("Publisher did not contain a description"),
+    )
     .expect("Unable to convert returned description");
 
     let mut subscriber = post::subscriber::Subscription::new(found_publisher_desc)


### PR DESCRIPTION
Now, the main test will use a descriptor from the meetup service when
creating the subscriber. It will also check that there are more than
zero publishers registered.

To support this, publishers will now wait on registration as was
documented. To do that, a oneshot was used. This requires a new error
type to be added in the event that both sides of the oneshot are closed.

Having the meetup panic instead of return an empty list when nothing was
found is an unexpected failure. It will now return an empty list.
Regexes are still to be implemented/changed out.