### PR TITLE
Adds PublisherStore for greater flexibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Run Clippy against main lib
       run: cargo clippy --workspace --exclude tests
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --test-threads=1
+      env:
+          RUST_LOG: info
     - name: Rust Format
       run: cargo fmt -- --check

--- a/src/bin/post_meetup.rs
+++ b/src/bin/post_meetup.rs
@@ -3,8 +3,8 @@ use clap::{crate_authors, App as ClApp, Arg};
 use futures::future;
 use futures::StreamExt;
 use log::*;
-use std::result::Result;
 use std::time;
+use std::{collections::HashMap, result::Result, sync::RwLock};
 use std::{convert::TryInto, net::ToSocketAddrs};
 use time::Duration;
 
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let bind_info = matches.value_of("bind").unwrap().parse().unwrap();
 
-    let publisher_store = HashMapPublisherStore::new();
+    let publisher_store = HashMapPublisherStore::new(RwLock::new(HashMap::new()));
     let meetup_server_options = MeetupServerOptions {
         publisher_timeout: publisher_timeout,
         publisher_store: publisher_store.clone(),

--- a/src/bin/post_meetup.rs
+++ b/src/bin/post_meetup.rs
@@ -9,9 +9,9 @@ use std::{convert::TryInto, net::ToSocketAddrs};
 use time::Duration;
 
 use post::find_service::{
+    hash_map_publisher_store::HashMapPublisherStore,
     proto::find_me_server::FindMeServer,
     server::{MeetupServer, MeetupServerOptions, PublisherStore},
-    vec_publisher_store::VecPublisherStore,
 };
 use tonic::transport::Server;
 
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let bind_info = matches.value_of("bind").unwrap().parse().unwrap();
 
-    let publisher_store = VecPublisherStore::new();
+    let publisher_store = HashMapPublisherStore::new();
     let meetup_server_options = MeetupServerOptions {
         publisher_timeout: publisher_timeout,
         publisher_store: publisher_store.clone(),
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn remove_expired_publishers(publisher_store: VecPublisherStore, i: time::Duration) {
+fn remove_expired_publishers(publisher_store: HashMapPublisherStore, i: time::Duration) {
     tokio::spawn(tokio::time::interval(i).for_each(move |_| {
         let now = time::SystemTime::now();
         let publishers = publisher_store.get_publishers();

--- a/src/bin/post_meetup.rs
+++ b/src/bin/post_meetup.rs
@@ -91,25 +91,23 @@ fn remove_expired_publishers(publisher_store: VecPublisherStore, i: time::Durati
         let publishers_to_remove: Vec<String> = publishers
             .into_iter()
             .filter(|publisher_tuple| {
-                let filter_out;
+                let mut filter_out = true;
                 if let Some(pub_info) = &publisher_tuple.1.info {
                     if let Some(expiration) = &pub_info.expiration {
                         match expiration.try_into() {
                             Result::<time::SystemTime, _>::Ok(proto_time) => {
-                                filter_out = proto_time > now
+                                filter_out = proto_time < now;
+                                debug!("checking time proto_time: {:?}, now: {:?}, should filter out: {:?}", proto_time, now, filter_out);
                             }
                             Err(error) => {
                                 error!("Removing descriptor, Invalid time: {}", error);
-                                filter_out = true;
                             }
                         };
                     } else {
                         error!("Removing descriptor, No Expiration");
-                        filter_out = true;
                     }
                 } else {
                     error!("Removing descriptor, No ConnectionInfo");
-                    filter_out = true;
                 }
                 filter_out
             })

--- a/src/bin/post_meetup.rs
+++ b/src/bin/post_meetup.rs
@@ -1,14 +1,17 @@
 extern crate tokio;
 use clap::{crate_authors, App as ClApp, Arg};
+use futures::future;
+use futures::StreamExt;
 use log::*;
-use std::net::ToSocketAddrs;
 use std::result::Result;
 use std::time;
+use std::{convert::TryInto, net::ToSocketAddrs};
 use time::Duration;
 
 use post::find_service::{
     proto::find_me_server::FindMeServer,
-    server::{MeetupServer, MeetupServerOptions},
+    server::{MeetupServer, MeetupServerOptions, PublisherStore},
+    vec_publisher_store::VecPublisherStore,
 };
 use tonic::transport::Server;
 
@@ -61,21 +64,62 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let bind_info = matches.value_of("bind").unwrap().parse().unwrap();
 
+    let publisher_store = VecPublisherStore::new();
     let meetup_server_options = MeetupServerOptions {
         publisher_timeout: publisher_timeout,
-        publisher_scan_interval: scan_interval,
+        publisher_store: publisher_store.clone(),
     };
+
     let meetup_server = MeetupServer::new(meetup_server_options);
-    meetup_server.start_remove_process();
 
     let server = Server::builder()
         .add_service(FindMeServer::new(meetup_server))
         .serve(bind_info);
 
     info!("Started server {}", bind_info);
+    remove_expired_publishers(publisher_store, scan_interval);
     server.await?;
 
     Ok(())
+}
+
+fn remove_expired_publishers(publisher_store: VecPublisherStore, i: time::Duration) {
+    tokio::spawn(tokio::time::interval(i).for_each(move |_| {
+        let now = time::SystemTime::now();
+        let publishers = publisher_store.get_publishers();
+
+        let publishers_to_remove: Vec<String> = publishers
+            .into_iter()
+            .filter(|publisher_tuple| {
+                let filter_out;
+                if let Some(pub_info) = &publisher_tuple.1.info {
+                    if let Some(expiration) = &pub_info.expiration {
+                        match expiration.try_into() {
+                            Result::<time::SystemTime, _>::Ok(proto_time) => {
+                                filter_out = proto_time > now
+                            }
+                            Err(error) => {
+                                error!("Removing descriptor, Invalid time: {}", error);
+                                filter_out = true;
+                            }
+                        };
+                    } else {
+                        error!("Removing descriptor, No Expiration");
+                        filter_out = true;
+                    }
+                } else {
+                    error!("Removing descriptor, No ConnectionInfo");
+                    filter_out = true;
+                }
+                filter_out
+            })
+            .map(|publisher_tuple| publisher_tuple.0)
+            .collect();
+
+        publisher_store.remove_publishers(&publishers_to_remove);
+
+        future::ready(())
+    }));
 }
 
 pub fn socket_validator(v: String) -> Result<(), String> {

--- a/src/find_service.rs
+++ b/src/find_service.rs
@@ -1,7 +1,7 @@
+pub mod hash_map_publisher_store;
 /// The find service protobuf back end. Use this when writing a Meetup service.
 pub mod proto;
 pub mod server;
-pub mod vec_publisher_store;
 
 use super::PublisherDesc;
 use convert::{TryFrom, TryInto};

--- a/src/find_service.rs
+++ b/src/find_service.rs
@@ -1,6 +1,7 @@
 /// The find service protobuf back end. Use this when writing a Meetup service.
 pub mod proto;
 pub mod server;
+pub mod vec_publisher_store;
 
 use super::PublisherDesc;
 use convert::{TryFrom, TryInto};

--- a/src/find_service/hash_map_publisher_store.rs
+++ b/src/find_service/hash_map_publisher_store.rs
@@ -6,19 +6,19 @@ use std::sync::{Arc, RwLock};
 type PublisherStoreMap = Arc<RwLock<HashMap<String, proto::Registration>>>;
 
 #[derive(Clone)]
-pub struct VecPublisherStore {
+pub struct HashMapPublisherStore {
     publishers_map: PublisherStoreMap,
 }
 
-impl PublisherStore for VecPublisherStore {
-    fn insert_publisher(&self, publisher_name: &String, registration: proto::Registration) {
+impl PublisherStore for HashMapPublisherStore {
+    fn insert_publisher(&self, publisher_name: &str, registration: proto::Registration) {
         self.publishers_map
             .write()
             .unwrap()
             .insert(publisher_name.to_string(), registration);
     }
 
-    fn remove_publisher(&self, publisher_name: &String) -> Result<(), PublisherNotFoundError> {
+    fn remove_publisher(&self, publisher_name: &str) -> Result<(), PublisherNotFoundError> {
         let mut locked_publishers = self.publishers_map.write().unwrap();
         let has_key = locked_publishers.contains_key(publisher_name);
 
@@ -28,13 +28,6 @@ impl PublisherStore for VecPublisherStore {
 
         locked_publishers.remove(publisher_name);
         Ok(())
-    }
-
-    fn remove_publishers(&self, publisher_names: &Vec<String>) {
-        let mut locked_publishers = self.publishers_map.write().unwrap();
-        for publisher_name in publisher_names {
-            locked_publishers.remove(publisher_name);
-        }
     }
 
     fn get_publishers(&self) -> Vec<(String, proto::Registration)> {
@@ -47,14 +40,14 @@ impl PublisherStore for VecPublisherStore {
         publisher_pairs
     }
 
-    fn find_publisher(&self, publisher_name: &String) -> Option<proto::Registration> {
+    fn find_publisher(&self, publisher_name: &str) -> Option<proto::Registration> {
         let locked_map = self.publishers_map.read().unwrap();
         let registration = locked_map.get(publisher_name).unwrap().clone();
 
         Some(registration)
     }
 
-    fn find_publishers(&self, search_str: &String) -> Vec<(String, proto::Registration)> {
+    fn find_publishers(&self, search_str: &str) -> Vec<(String, proto::Registration)> {
         let locked_map = self.publishers_map.read().unwrap();
         let mut new_vec = vec![];
         for pair in locked_map.clone() {
@@ -67,9 +60,9 @@ impl PublisherStore for VecPublisherStore {
     }
 }
 
-impl VecPublisherStore {
-    pub fn new() -> VecPublisherStore {
-        VecPublisherStore {
+impl HashMapPublisherStore {
+    pub fn new() -> HashMapPublisherStore {
+        HashMapPublisherStore {
             publishers_map: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -77,7 +70,7 @@ impl VecPublisherStore {
 
 #[test]
 fn get_all_test() {
-    let vec_store = VecPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new();
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -92,7 +85,7 @@ fn get_all_test() {
 
 #[test]
 fn get_single_by_name_test() {
-    let vec_store = VecPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new();
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -107,7 +100,7 @@ fn get_single_by_name_test() {
 
 #[test]
 fn remove_single_publisher_by_name_test() {
-    let vec_store = VecPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new();
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -131,7 +124,7 @@ fn remove_single_publisher_by_name_test() {
 
 #[test]
 fn remove_multiple_publishers_by_name_test() {
-    let vec_store = VecPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new();
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,

--- a/src/find_service/hash_map_publisher_store.rs
+++ b/src/find_service/hash_map_publisher_store.rs
@@ -3,23 +3,17 @@ use super::server::{PublisherNotFoundError, PublisherStore};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-type PublisherStoreMap = Arc<RwLock<HashMap<String, proto::Registration>>>;
-
-#[derive(Clone)]
-pub struct HashMapPublisherStore {
-    publishers_map: PublisherStoreMap,
-}
+pub type HashMapPublisherStore = Arc<RwLock<HashMap<String, proto::Registration>>>;
 
 impl PublisherStore for HashMapPublisherStore {
     fn insert_publisher(&self, publisher_name: &str, registration: proto::Registration) {
-        self.publishers_map
-            .write()
+        self.write()
             .unwrap()
             .insert(publisher_name.to_string(), registration);
     }
 
     fn remove_publisher(&self, publisher_name: &str) -> Result<(), PublisherNotFoundError> {
-        let mut locked_publishers = self.publishers_map.write().unwrap();
+        let mut locked_publishers = self.write().unwrap();
         let has_key = locked_publishers.contains_key(publisher_name);
 
         if !has_key {
@@ -31,7 +25,7 @@ impl PublisherStore for HashMapPublisherStore {
     }
 
     fn get_publishers(&self) -> Vec<(String, proto::Registration)> {
-        let locked_publishers = self.publishers_map.write().unwrap();
+        let locked_publishers = self.write().unwrap();
         let mut publisher_pairs = vec![];
         for publisher_name_pair in locked_publishers.clone() {
             publisher_pairs.push(publisher_name_pair);
@@ -41,14 +35,14 @@ impl PublisherStore for HashMapPublisherStore {
     }
 
     fn find_publisher(&self, publisher_name: &str) -> Option<proto::Registration> {
-        let locked_map = self.publishers_map.read().unwrap();
+        let locked_map = self.read().unwrap();
         let registration = locked_map.get(publisher_name).unwrap().clone();
 
         Some(registration)
     }
 
     fn find_publishers(&self, search_str: &str) -> Vec<(String, proto::Registration)> {
-        let locked_map = self.publishers_map.read().unwrap();
+        let locked_map = self.read().unwrap();
         let mut new_vec = vec![];
         for pair in locked_map.clone() {
             if (*pair.0).contains(search_str) {
@@ -60,17 +54,9 @@ impl PublisherStore for HashMapPublisherStore {
     }
 }
 
-impl HashMapPublisherStore {
-    pub fn new() -> HashMapPublisherStore {
-        HashMapPublisherStore {
-            publishers_map: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-}
-
 #[test]
 fn get_all_test() {
-    let vec_store = HashMapPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new(RwLock::new(HashMap::new()));
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -85,7 +71,7 @@ fn get_all_test() {
 
 #[test]
 fn get_single_by_name_test() {
-    let vec_store = HashMapPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new(RwLock::new(HashMap::new()));
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -100,7 +86,7 @@ fn get_single_by_name_test() {
 
 #[test]
 fn remove_single_publisher_by_name_test() {
-    let vec_store = HashMapPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new(RwLock::new(HashMap::new()));
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,
@@ -124,7 +110,7 @@ fn remove_single_publisher_by_name_test() {
 
 #[test]
 fn remove_multiple_publishers_by_name_test() {
-    let vec_store = HashMapPublisherStore::new();
+    let vec_store = HashMapPublisherStore::new(RwLock::new(HashMap::new()));
     let empty_registration = proto::Registration {
         publisher: None,
         info: None,

--- a/src/find_service/server.rs
+++ b/src/find_service/server.rs
@@ -22,12 +22,16 @@ impl fmt::Display for PublisherNotFoundError {
 }
 
 pub trait PublisherStore: Send + Sync + Clone + 'static {
-    fn insert_publisher(&self, publisher_name: &String, registration: proto::Registration);
-    fn remove_publisher(&self, publisher_name: &String) -> Result<(), PublisherNotFoundError>;
-    fn remove_publishers(&self, publisher_names: &Vec<String>);
-    fn find_publisher(&self, publisher_name: &String) -> Option<proto::Registration>;
+    fn insert_publisher(&self, publisher_name: &str, registration: proto::Registration);
+    fn remove_publisher(&self, publisher_name: &str) -> Result<(), PublisherNotFoundError>;
+    fn remove_publishers(&self, publisher_names: &[String]) {
+        for publisher in publisher_names {
+            let _ = self.remove_publisher(publisher);
+        }
+    }
+    fn find_publisher(&self, publisher_name: &str) -> Option<proto::Registration>;
     fn get_publishers(&self) -> Vec<(String, proto::Registration)>;
-    fn find_publishers(&self, search_str: &String) -> Vec<(String, proto::Registration)>;
+    fn find_publishers(&self, search_str: &str) -> Vec<(String, proto::Registration)>;
 }
 
 #[derive(Default, Clone)]

--- a/src/find_service/vec_publisher_store.rs
+++ b/src/find_service/vec_publisher_store.rs
@@ -58,7 +58,7 @@ impl PublisherStore for VecPublisherStore {
         let locked_map = self.publishers_map.read().unwrap();
         let mut new_vec = vec![];
         for pair in locked_map.clone() {
-            if (*pair.0).eq(search_str) {
+            if (*pair.0).contains(search_str) {
                 new_vec.push(pair);
             }
         }

--- a/src/find_service/vec_publisher_store.rs
+++ b/src/find_service/vec_publisher_store.rs
@@ -1,0 +1,160 @@
+use super::proto;
+use super::server::{PublisherNotFoundError, PublisherStore};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+type PublisherStoreMap = Arc<RwLock<HashMap<String, proto::Registration>>>;
+
+#[derive(Clone)]
+pub struct VecPublisherStore {
+    publishers_map: PublisherStoreMap,
+}
+
+impl PublisherStore for VecPublisherStore {
+    fn insert_publisher(&self, publisher_name: &String, registration: proto::Registration) {
+        self.publishers_map
+            .write()
+            .unwrap()
+            .insert(publisher_name.to_string(), registration);
+    }
+
+    fn remove_publisher(&self, publisher_name: &String) -> Result<(), PublisherNotFoundError> {
+        let mut locked_publishers = self.publishers_map.write().unwrap();
+        let has_key = locked_publishers.contains_key(publisher_name);
+
+        if !has_key {
+            error!("Publisher not found")
+        }
+
+        locked_publishers.remove(publisher_name);
+        Ok(())
+    }
+
+    fn remove_publishers(&self, publisher_names: &Vec<String>) {
+        let mut locked_publishers = self.publishers_map.write().unwrap();
+        for publisher_name in publisher_names {
+            locked_publishers.remove(publisher_name);
+        }
+    }
+
+    fn get_publishers(&self) -> Vec<(String, proto::Registration)> {
+        let locked_publishers = self.publishers_map.write().unwrap();
+        let mut publisher_pairs = vec![];
+        for publisher_name_pair in locked_publishers.clone() {
+            publisher_pairs.push(publisher_name_pair);
+        }
+
+        publisher_pairs
+    }
+
+    fn find_publisher(&self, publisher_name: &String) -> Option<proto::Registration> {
+        let locked_map = self.publishers_map.read().unwrap();
+        let registration = locked_map.get(publisher_name).unwrap().clone();
+
+        Some(registration)
+    }
+
+    fn find_publishers(&self, search_str: &String) -> Vec<(String, proto::Registration)> {
+        let locked_map = self.publishers_map.read().unwrap();
+        let mut new_vec = vec![];
+        for pair in locked_map.clone() {
+            if (*pair.0).eq(search_str) {
+                new_vec.push(pair);
+            }
+        }
+
+        new_vec
+    }
+}
+
+impl VecPublisherStore {
+    pub fn new() -> VecPublisherStore {
+        VecPublisherStore {
+            publishers_map: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[test]
+fn get_all_test() {
+    let vec_store = VecPublisherStore::new();
+    let empty_registration = proto::Registration {
+        publisher: None,
+        info: None,
+    };
+
+    vec_store.insert_publisher(&"test_name".to_string(), empty_registration);
+
+    let publisher_pairs = vec_store.find_publishers(&"test_name".to_string());
+    assert_eq!(publisher_pairs.len(), 1);
+    assert_eq!(publisher_pairs.get(0).unwrap().0, "test_name".to_string());
+}
+
+#[test]
+fn get_single_by_name_test() {
+    let vec_store = VecPublisherStore::new();
+    let empty_registration = proto::Registration {
+        publisher: None,
+        info: None,
+    };
+
+    vec_store.insert_publisher(&"test_name".to_string(), empty_registration.clone());
+
+    let publisher_registration = vec_store.find_publisher(&"test_name".to_string());
+    assert!(publisher_registration.is_some());
+    assert_eq!(publisher_registration.unwrap(), empty_registration);
+}
+
+#[test]
+fn remove_single_publisher_by_name_test() {
+    let vec_store = VecPublisherStore::new();
+    let empty_registration = proto::Registration {
+        publisher: None,
+        info: None,
+    };
+
+    vec_store.insert_publisher(&"test_name".to_string(), empty_registration);
+
+    let mut publisher_pairs = vec_store.find_publishers(&"test_name".to_string());
+    assert_eq!(publisher_pairs.len(), 1);
+
+    let remove_result = vec_store.remove_publisher(&"test_name".to_string());
+    assert!(remove_result.is_ok(), "Expected ok removal");
+
+    publisher_pairs = vec_store.get_publishers();
+    assert_eq!(
+        publisher_pairs.len(),
+        0,
+        "Incorrect number of publishers returned"
+    );
+}
+
+#[test]
+fn remove_multiple_publishers_by_name_test() {
+    let vec_store = VecPublisherStore::new();
+    let empty_registration = proto::Registration {
+        publisher: None,
+        info: None,
+    };
+
+    vec_store.insert_publisher(&"test_name_1".to_string(), empty_registration.clone());
+    vec_store.insert_publisher(&"test_name_2".to_string(), empty_registration.clone());
+    vec_store.insert_publisher(&"test_name_3".to_string(), empty_registration.clone());
+
+    let mut publisher_pairs = vec_store.get_publishers();
+    assert_eq!(publisher_pairs.len(), 3);
+
+    let names_to_remove = vec![
+        "test_name_1".to_string(),
+        "test_name_2".to_string(),
+        "test_name_3".to_string(),
+    ];
+
+    vec_store.remove_publishers(&names_to_remove);
+    publisher_pairs = vec_store.get_publishers();
+    assert_eq!(
+        publisher_pairs.len(),
+        0,
+        "Incorrect number of publishers returned"
+    );
+}

--- a/tests/common/find_service_setup.rs
+++ b/tests/common/find_service_setup.rs
@@ -39,6 +39,10 @@ impl FindService {
         let bind = "127.0.0.1:8080";
 
         let _proc = tokio::process::Command::new(path)
+            .arg("-s")
+            .arg("5")
+            .arg("-t")
+            .arg("5")
             .arg("--bind")
             .arg(bind)
             .kill_on_drop(true)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ pub struct CommonTestEnvironment {
 }
 
 pub async fn setup() -> CommonTestEnvironment {
-    env_logger::init();
+    let _ = env_logger::try_init();
     eprintln!("path:{:?}", std::env::current_dir().unwrap());
 
     let find = FindService::new().await;

--- a/tests/publisher_subscriber.rs
+++ b/tests/publisher_subscriber.rs
@@ -154,7 +154,7 @@ async fn publisher_cleanup() {
     };
 
     log::debug!("Creating publisher");
-    let mut _publisher = post::publisher::Publisher::from_description(desc.clone(), client.clone())
+    let _publisher = post::publisher::Publisher::from_description(desc.clone(), client.clone())
         .await
         .expect("Unable to create Publisher");
 


### PR DESCRIPTION
PublisherStore trait adds the ability for developers to add their own publisher backing store with their own thread-safe implementations/concurrency requirements.